### PR TITLE
Now supports characters with accents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "encode_unicode"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +245,7 @@ name = "unf"
 version = "1.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deunicode 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "promptly 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -293,6 +299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum deunicode 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307dde1a517939465bc4042b47377284a56cee6160f8066f1f5035eb7b25a3fc"
 "checksum encode_unicode 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "28d65f1f5841ef7c6792861294b72beda34c664deb8be27970f36c306b7da1ce"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ clap = "2.33.0"
 lazy_static = "1.4.0"
 regex = "1.3.1"
 promptly = "0.1.5"
+deunicode = "1.1.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ unf [FLAGS] <PATH>...
 
 ``` sh
 $ unf 🤔😀😃😄😁😆😅emojis.txt
-rename '🤔😀😃😄😁😆😅emojis.txt' -> 'emojis.txt'? (y/N): y
+rename '🤔😀😃😄😁😆😅emojis.txt' -> 'thinking_grinning_smiley_smile_grin_laughing_sweat_smile_emojis.txt'? (y/N): y
 ```
 
 ``` sh
 $ unf -f 'Game (Not Pirated 😉).rar'
-rename 'Game (Not Pirated 😉).rar' -> 'Game_Not_Pirated.rar'
+rename 'Game (Not Pirated 😉).rar' -> 'Game_Not_Pirated_wink.rar'
 ```
 
 ### Recursion


### PR DESCRIPTION
Hi, 

I've added a feature which, instead of deleting characters with accents (such as a, é, Ï...), replaces them with the letter without accent. I've also added two unit tests for this feature.

I've used an HashMap to store accented characters and their unaccented counterpart. This map has a type `<char, char> `which allows it to be lazy static as well, but forces a little `String/str/byte` dance afterward.

This my first ever "real code" in Rust and first ever Pull Request,  please tell me if I've done anything wrong.